### PR TITLE
Change the way text block processes actions

### DIFF
--- a/DialogSystem/Dialog.cs
+++ b/DialogSystem/Dialog.cs
@@ -101,6 +101,12 @@ public class Dialog
                     }
                 }
                 break;
+            case DialogActionType.ConditionalJump:
+                if (action is ConditionalJumpAction cond)
+                {
+                    
+                }
+                break;
             case DialogActionType.SpeakerStateChange:
                 break;
         }

--- a/DialogSystem/Dialog.cs
+++ b/DialogSystem/Dialog.cs
@@ -104,7 +104,40 @@ public class Dialog
             case DialogActionType.ConditionalJump:
                 if (action is ConditionalJumpAction cond)
                 {
-                    
+                    DialogVariable variable = Variables[cond.VariableName];
+                    DialogVariable other = cond.Value ?? Variables[cond.VariableValue ?? throw new System.NullReferenceException("No value for variable comparison was provided")];
+                    int comparison = variable.Compare(other);
+                    switch (cond.ConditionType)
+                    {
+                        case ConditionType.Equal:
+                            if (comparison == 0)
+                            {
+                                AdvanceDialog(cond.Destination);
+                                System.Console.WriteLine($"Jumping to {cond.Destination}");
+                            }
+                            break;
+                        case ConditionType.LessThen:
+                            if (comparison == -1)
+                            {
+                                AdvanceDialog(cond.Destination);
+                                System.Console.WriteLine($"Jumping to {cond.Destination}");
+                            }
+                            break;
+                        case ConditionType.GreaterThen:
+                            if (comparison == 1)
+                            {
+                                AdvanceDialog(cond.Destination);
+                                System.Console.WriteLine($"Jumping to {cond.Destination}");
+                            }
+                            break;
+                        case ConditionType.NotEqual:
+                            if (comparison != 0)
+                            {
+                                AdvanceDialog(cond.Destination);
+                                System.Console.WriteLine($"Jumping to {cond.Destination}");
+                            }
+                            break;
+                    }
                 }
                 break;
             case DialogActionType.SpeakerStateChange:

--- a/DialogSystem/DialogAction/ConditionalJumpAction.cs
+++ b/DialogSystem/DialogAction/ConditionalJumpAction.cs
@@ -1,0 +1,35 @@
+namespace DialogSystem;
+
+public enum ConditionType
+{
+    Equal,
+    LessThen,
+    GreaterThen,
+    NotEqual
+}
+/// <summary>
+/// Conditional jump action works in the same way as jump action but only executes if given condition is true
+/// </summary>
+public class ConditionalJumpAction : DialogSystem.DialogActionBase
+{
+    public ConditionalJumpAction(string destination, string variableName, ConditionType conditionType, DialogVariable? value, string? variableValue)
+    {
+        Destination = destination;
+        VariableName = variableName;
+        Value = value;
+        VariableValue = variableValue;
+        _type = DialogActionType.ConditionalJump;
+        ConditionType = conditionType;
+    }
+    public ConditionType ConditionType { get; set; }
+    public string Destination { get; set; }
+    public string VariableName { get; set; }
+    /// <summary>
+    /// Constant value to compare against
+    /// </summary>
+    public DialogVariable? Value { get; set; }
+    /// <summary>
+    /// Name of the variable to compare against
+    /// </summary>
+    public string? VariableValue { get; set; }
+}

--- a/DialogSystem/DialogAction/ConditionalJumpAction.cs
+++ b/DialogSystem/DialogAction/ConditionalJumpAction.cs
@@ -22,7 +22,15 @@ public class ConditionalJumpAction : DialogSystem.DialogActionBase
         ConditionType = conditionType;
     }
     public ConditionType ConditionType { get; set; }
+    /// <summary>
+    /// Where will dialog jump to
+    /// </summary>
+    /// <value></value>
     public string Destination { get; set; }
+    /// <summary>
+    /// Name of the variable that everything will be compared with
+    /// </summary>
+    /// <value></value>
     public string VariableName { get; set; }
     /// <summary>
     /// Constant value to compare against

--- a/DialogSystem/DialogAction/SpeakerMoveAction.cs
+++ b/DialogSystem/DialogAction/SpeakerMoveAction.cs
@@ -15,5 +15,6 @@ public class SpeakerMoveAction : DialogActionBase
         Target = target;
         TargetPosition = position;
         _type = DialogActionType.SpeakerMove;
+        _skippable = false;
     }
 }

--- a/DialogSystem/DialogAction/TextAction.cs
+++ b/DialogSystem/DialogAction/TextAction.cs
@@ -11,5 +11,6 @@ public class TextAction : DialogSystem.DialogActionBase
         _type = DialogActionType.Text;
         Text = text;
         Speaker = speaker;
+        _skippable = false;
     }
 }

--- a/DialogSystem/DialogActionBase.cs
+++ b/DialogSystem/DialogActionBase.cs
@@ -43,6 +43,15 @@ public enum DialogActionType
 /// </summary>
 public abstract class DialogActionBase
 {
+    /// <summary>
+    /// Defines type of the action<br/>
+    /// This must be same as the class as this is used for casting types
+    /// </summary>
     protected DialogActionType _type;
+    /// <summary>
+    /// Defines if this action can be auto skipped, instead of waiting for player input
+    /// </summary>
+    protected bool _skippable = true;
+    public bool Skippable => _skippable;
     public DialogActionType Action => _type;
 }

--- a/DialogSystem/DialogActionBase.cs
+++ b/DialogSystem/DialogActionBase.cs
@@ -29,6 +29,10 @@ public enum DialogActionType
     /// </summary>
     Jump,
     /// <summary>
+    /// Jump to other block in the dialog if condition is satisfied
+    /// </summary>
+    ConditionalJump,
+    /// <summary>
     /// Any action that involves variable modification
     /// </summary>
     Variable,

--- a/DialogSystem/DialogBlocks/DialogTextBlock.cs
+++ b/DialogSystem/DialogBlocks/DialogTextBlock.cs
@@ -31,6 +31,10 @@ public class DialogTextBlock : DialogSystem.DialogBlockBase
     }
     private void _changeLine(int lineId)
     {
+        if (lineId >= Actions.Count)
+        {
+            return;
+        }
         _currentLine = lineId;
         switch (Actions[_currentLine].Action)
         {
@@ -55,15 +59,30 @@ public class DialogTextBlock : DialogSystem.DialogBlockBase
     {
         if (Game.CurrentState != GameState.Normal)
             return;
-        if (++_currentLine < Actions.Count)
+        if (!Actions[_currentLine].Skippable)
         {
-            _changeLine(_currentLine);
-        }
-        else
-        {
-            throw new System.Exception("Unexpected end of dialog reached");
+            if (++_currentLine < Actions.Count)
+            {
+                _changeLine(_currentLine);
+            }
+            else
+            {
+                throw new System.Exception("Unexpected end of dialog reached");
+            }
         }
     }
+
+    public override void Update(GameTime gameTime)
+    {
+        base.Update(gameTime);
+        //we run dialog line in updates to avoid freezing up game
+        // if there are too many actions that don't require player input
+        if (_currentLine < Actions.Count && Actions[_currentLine].Skippable)
+        {
+            _changeLine(_currentLine + 1);
+        }
+    }
+
     public override void ChangeActions(List<DialogActionBase> actions)
     {
         base.ChangeActions(actions);

--- a/DialogSystem/DialogParser.cs
+++ b/DialogSystem/DialogParser.cs
@@ -224,13 +224,13 @@ public class DialogParser
             {
                 type = ConditionType.LessThen;
             }
-            if (Regex.IsMatch(condition.Value, @"more(\s+)then"))
+            if (Regex.IsMatch(condition.Value, @"((more)|(greater))(\s+)then"))
             {
                 type = ConditionType.GreaterThen;
             }
             if (Regex.IsMatch(condition.Value, @"equal(\s+)to"))
             {
-                type = ConditionType.LessThen;
+                type = ConditionType.Equal;
             }
             if (Regex.IsMatch(condition.Value, @"not(\s+)equal(\s+)to"))
             {

--- a/DialogSystem/DialogVariable.cs
+++ b/DialogSystem/DialogVariable.cs
@@ -18,7 +18,7 @@ public class DialogVariable
         StringValue = value;
     }
 
-    public DialogVariable( float value)
+    public DialogVariable(float value)
     {
         VariableType = DialogVariableType.Number;
         NumberValue = value;
@@ -49,6 +49,32 @@ public class DialogVariable
                 return StringValue;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Compares two values depending on which type they are
+    /// </summary>
+    /// <param name="variable"></param>
+    /// <returns>
+    /// 0 if equal, 1 if greater then, -1 if less then for int<br/>
+    /// and 0 if equal and -1 if not equal for string
+    /// </returns>
+    public int Compare(DialogVariable variable)
+    {
+        if (variable.VariableType != VariableType)
+        {
+            throw new System.Exception("Dialog variable types need to have matching data type. String can not be compared to number");
+        }
+        switch (VariableType)
+        {
+            case DialogVariableType.String:
+                return variable.StringValue == StringValue ? 0 : -1;
+            case DialogVariableType.Number:
+                return NumberValue == variable.NumberValue ? 0 :
+                NumberValue > variable.NumberValue ? 1 : -1;
+            default:
+                throw new System.Exception("Invalid operation reached");
+        }
     }
 
     public override string ToString()

--- a/test.diag
+++ b/test.diag
@@ -41,8 +41,8 @@ skull: also look number -> $AGE$
 set $AGE$ to 29
 skull: NoW iT's DifFeReNt "$AGE$"
 change $AGE$ by -9
-jump to die if $AGE$ is greater then 0
-jump to born if $AGE$ is equal to $IDK$
+jump to die if $AGE$ is equal to 0
+jump to born if $AGE$ is greater then $IDK$
 skull:SuBtRaCtiOn #$AGE$#
 speaker skull move right
 girl: woah

--- a/test.diag
+++ b/test.diag
@@ -26,6 +26,7 @@ position = offscreen
 [variables]
 USERNAME = "Mieclesoft Bimbows"
 AGE = 26
+IDK = 4
 
 #these are block types
 [dialog]
@@ -40,6 +41,8 @@ skull: also look number -> $AGE$
 set $AGE$ to 29
 skull: NoW iT's DifFeReNt "$AGE$"
 change $AGE$ by -9
+jump to die if $AGE$ is greater then 0
+jump to born if $AGE$ is equal to $IDK$
 skull:SuBtRaCtiOn #$AGE$#
 speaker skull move right
 girl: woah


### PR DESCRIPTION
Instead of only processing actions upon player clicking label
It will instead *always* process actions and wait for player to click the label *only* when action doesn't want to be skipped